### PR TITLE
Modernize project for TensorFlow 2 compatibility

### DIFF
--- a/Clash Royale Helper/Clash Royale Helper/Clash_Royale_Helper.py
+++ b/Clash Royale Helper/Clash Royale Helper/Clash_Royale_Helper.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 # Used for predictions
-from keras.models import load_model
+from tensorflow.keras.models import load_model
 
 # Used for live predictions
 import time
@@ -14,9 +14,7 @@ from PIL import Image
 
 # Setting up data
 import cv2
-from keras.preprocessing.image import img_to_array
-from keras.preprocessing.image import array_to_img
-from keras.utils import to_categorical
+from tensorflow.keras.preprocessing.image import img_to_array
 from imutils import paths
 
 from load_train_test_1 import loadTestingImages1

--- a/Clash Royale Helper/Clash Royale Helper/LeNetClass.py
+++ b/Clash Royale Helper/Clash Royale Helper/LeNetClass.py
@@ -1,12 +1,12 @@
 import numpy as np
-from keras.models import Sequential
-from keras.layers.convolutional import Conv2D
-from keras.layers.convolutional import MaxPooling2D
-from keras.layers.core import Activation
-from keras.layers.core import Flatten
-from keras.layers.core import Dense
-from keras.layers.core import Dropout
-from keras import backend as K
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Conv2D
+from tensorflow.keras.layers import MaxPooling2D
+from tensorflow.keras.layers import Activation
+from tensorflow.keras.layers import Flatten
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.layers import Dropout
+from tensorflow.keras import backend as K
 
 
 class LeNet:

--- a/Clash Royale Helper/Clash Royale Helper/load_train_test_1.py
+++ b/Clash Royale Helper/Clash Royale Helper/load_train_test_1.py
@@ -2,9 +2,7 @@ import numpy as np
 
 # Setting up data
 import cv2
-from keras.preprocessing.image import img_to_array
-from keras.preprocessing.image import array_to_img
-from keras.utils import to_categorical
+from tensorflow.keras.preprocessing.image import img_to_array
 from imutils import paths
 
 def loadTrainingImages1():

--- a/Clash Royale Helper/Clash Royale Helper/load_train_test_2.py
+++ b/Clash Royale Helper/Clash Royale Helper/load_train_test_2.py
@@ -2,9 +2,7 @@ import numpy as np
 
 # Setting up data
 import cv2
-from keras.preprocessing.image import img_to_array
-from keras.preprocessing.image import array_to_img
-from keras.utils import to_categorical
+from tensorflow.keras.preprocessing.image import img_to_array
 from imutils import paths
 
 from random import randint

--- a/Clash Royale Helper/Clash Royale Helper/train_predict_cards.py
+++ b/Clash Royale Helper/Clash Royale Helper/train_predict_cards.py
@@ -1,21 +1,19 @@
 import numpy as np
 
 # Training the data
-from keras.utils import to_categorical
+from tensorflow.keras.utils import to_categorical
 from LeNetClass import LeNet
 # Used for aug data gen
-from keras.preprocessing.image import ImageDataGenerator
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
 # Used for training
-from keras.optimizers import Adam
+from tensorflow.keras.optimizers import Adam
 
 # Setting up data
 import cv2
-from keras.preprocessing.image import img_to_array
-from keras.preprocessing.image import array_to_img
-from keras.utils import to_categorical
+from tensorflow.keras.preprocessing.image import img_to_array
 from imutils import paths
 # Used for predictions
-from keras.models import load_model
+from tensorflow.keras.models import load_model
 
 # Used for live predictions
 import time
@@ -55,14 +53,14 @@ def trainModel1():
 
     print("[INFO] compiling model...")
     model = LeNet.build(width=32, height=32, depth=3, classes=96)
-    opt = Adam(lr=INIT_LR, decay=INIT_LR/EPOCHS)
-    model.compile(loss="binary_crossentropy", optimizer=opt, metrics=["accuracy"])
+    opt = Adam(learning_rate=INIT_LR)
+    model.compile(loss="categorical_crossentropy", optimizer=opt, metrics=["accuracy"])
 
 
     print("[INFO] training network...")
-    H = model.fit_generator(aug.flow(x_train, y_train, batch_size=BS), 
-                            validation_data=(x_train, y_train), steps_per_epoch=len(x_train) // BS,
-                            epochs=EPOCHS, verbose=1)
+    H = model.fit(aug.flow(x_train, y_train, batch_size=BS),
+                  validation_data=(x_train, y_train), steps_per_epoch=len(x_train) // BS,
+                  epochs=EPOCHS, verbose=1)
 
     print("[INFO] serializing network...")
     model.save("testNet.model")
@@ -181,6 +179,8 @@ def liveModelPredicts1():
             startTime = time.time()
 
 # --- CNN 1 ---
-#trainModel1()
-modelPredicts1()
-#liveModelPredicts1()
+if __name__ == "__main__":
+    # Example usage
+    # trainModel1()
+    # liveModelPredicts1()
+    modelPredicts1()

--- a/Clash Royale Helper/Clash Royale Helper/train_predict_elixer.py
+++ b/Clash Royale Helper/Clash Royale Helper/train_predict_elixer.py
@@ -1,21 +1,19 @@
 import numpy as np
 
 # Training the data
-from keras.utils import to_categorical
+from tensorflow.keras.utils import to_categorical
 from LeNetClass import LeNet
 # Used for aug data gen
-from keras.preprocessing.image import ImageDataGenerator
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
 # Used for training
-from keras.optimizers import Adam
+from tensorflow.keras.optimizers import Adam
 
 # Setting up data
 import cv2
-from keras.preprocessing.image import img_to_array
-from keras.preprocessing.image import array_to_img
-from keras.utils import to_categorical
+from tensorflow.keras.preprocessing.image import img_to_array
 from imutils import paths
 # Used for predictions
-from keras.models import load_model
+from tensorflow.keras.models import load_model
 
 # Used for live predictions
 import time
@@ -48,14 +46,14 @@ def trainModel2():
 
     print("[INFO] compiling model...")
     model = LeNet.build(width=28, height=28, depth=3, classes=2)
-    opt = Adam(lr=INIT_LR, decay=INIT_LR/EPOCHS)
-    model.compile(loss="binary_crossentropy", optimizer=opt, metrics=["accuracy"])
+    opt = Adam(learning_rate=INIT_LR)
+    model.compile(loss="categorical_crossentropy", optimizer=opt, metrics=["accuracy"])
 
 
     print("[INFO] training network...")
-    H = model.fit_generator(aug.flow(x_train, y_train, batch_size=BS), 
-                            validation_data=(x_train, y_train), steps_per_epoch=len(x_train) // BS,
-                            epochs=EPOCHS, verbose=1)
+    H = model.fit(aug.flow(x_train, y_train, batch_size=BS),
+                  validation_data=(x_train, y_train), steps_per_epoch=len(x_train) // BS,
+                  epochs=EPOCHS, verbose=1)
 
     print("[INFO] serializing network...")
     model.save("testNet2.model")
@@ -145,8 +143,10 @@ def liveModelPredicts2():
             startTime = time.time()
 
 # --- CNN 2 ---
-generateTrainingImages2()
-labelTrainingData2()
-trainModel2()
-modelPredicts2()
-liveModelPredicts2()
+if __name__ == "__main__":
+    # Example usage
+    # generateTrainingImages2()
+    # labelTrainingData2()
+    # trainModel2()
+    modelPredicts2()
+    # liveModelPredicts2()

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Currently, the code is *not* commented very well. This will change soon.
 
-I wrote a report explaining how this AI Assistant was made. It's tailored towards an non-computer-science audience. Please see: [Rough Draft Report](https://github.com/AmarSaini/Clash-Royale-AI-Card-Tracker/blob/master/Clash%20Royale%20Helper/Document/Report.pdf)
+I wrote a report explaining how this AI Assistant was made. It's tailored towards a non-computer-science audience. Please see: [Rough Draft Report](https://github.com/AmarSaini/Clash-Royale-AI-Card-Tracker/blob/master/Clash%20Royale%20Helper/Document/Report.pdf)
 
 Libraries Used:
-- openCV (Image Preprocessing)
-- Keras/TensorFlow (Convolutional Neural Networks)
+- OpenCV (Image preprocessing)
+- TensorFlow/Keras (Convolutional neural networks)
 - TkInter (GUI)
-- PIL (Mapping images into GUI)
+- Pillow (mapping images into GUI)
 
 If you still want to see the code for the following:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+tensorflow>=2.15.0
+opencv-python
+Pillow
+imutils
+numpy
+


### PR DESCRIPTION
## Summary
- replace legacy Keras imports with `tf.keras`
- update training scripts to use `fit` and `Adam(learning_rate)`
- add `if __name__ == "__main__"` guards and a requirements file
- refresh README to mention current dependencies
- switch training scripts to `categorical_crossentropy` for proper multi-class handling

## Testing
- `python -m py_compile 'Clash Royale Helper/Clash Royale Helper/Clash_Royale_Helper.py' 'Clash Royale Helper/Clash Royale Helper/LeNetClass.py' 'Clash Royale Helper/Clash Royale Helper/load_train_test_1.py' 'Clash Royale Helper/Clash Royale Helper/load_train_test_2.py' 'Clash Royale Helper/Clash Royale Helper/train_predict_cards.py' 'Clash Royale Helper/Clash Royale Helper/train_predict_elixer.py'`


------
https://chatgpt.com/codex/tasks/task_e_68a7639268c08323aed842a97236b3ac